### PR TITLE
#6 🌟 Implement CPU performance module

### DIFF
--- a/kamper/api/src/commonMain/kotlin/com/smellouk/kamper/api/Watcher.kt
+++ b/kamper/api/src/commonMain/kotlin/com/smellouk/kamper/api/Watcher.kt
@@ -12,6 +12,7 @@ open class Watcher<I : Info>(
     private val defaultDispatcher: CoroutineDispatcher,
     private val mainDispatcher: CoroutineDispatcher,
     private val infoRepository: InfoRepository<I>,
+    private val logger: Logger
 ) {
     private var job: Job? = null
 
@@ -24,11 +25,11 @@ open class Watcher<I : Info>(
                 val info = try {
                     infoRepository.getInfo()
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                    logger.log(e.stackTraceToString())
                     null
                 }
                 if (info != null) {
-                    println(info)
+                    logger.log(info.toString())
                     withContext(mainDispatcher) {
                         listeners.forEach { listener ->
                             listener.invoke(info)

--- a/kamper/engine/src/commonMain/kotlin/com.smellouk.kamper/Engine.kt
+++ b/kamper/engine/src/commonMain/kotlin/com.smellouk.kamper/Engine.kt
@@ -45,7 +45,7 @@ open class Engine {
     }
 
     inline fun <reified I : Info> addInfoListener(noinline listener: InfoListener<I>): Engine {
-        println(mapListeners)
+        logger.log(mapListeners.toString())
         mapListeners[I::class]?.add(listener)
         return this
     }

--- a/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/Module.kt
+++ b/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/Module.kt
@@ -1,0 +1,43 @@
+package com.smellouk.kamper.cpu
+
+import com.smellouk.kamper.api.KamperDslMarker
+import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.api.Performance
+import com.smellouk.kamper.api.PerformanceModule
+import com.smellouk.kamper.api.Watcher
+import com.smellouk.kamper.cpu.repository.CpuInfoMapper
+import com.smellouk.kamper.cpu.repository.CpuInfoRepositoryImpl
+import com.smellouk.kamper.cpu.repository.source.ProcCpuInfoSource
+import com.smellouk.kamper.cpu.repository.source.ShellCpuInfoSource
+import kotlinx.coroutines.Dispatchers
+
+actual val CpuModule: PerformanceModule<CpuConfig, CpuInfo> = PerformanceModule(
+    config = CpuConfig.DEFAULT,
+    performance = createPerformance(CpuConfig.DEFAULT.logger)
+)
+
+@KamperDslMarker
+@Suppress("FunctionNaming")
+fun CpuModule(
+    builder: CpuConfig.Builder.() -> Unit
+): PerformanceModule<CpuConfig, CpuInfo> = with(CpuConfig.Builder.apply(builder).build()) {
+    PerformanceModule(
+        config = this,
+        performance = createPerformance(logger)
+    )
+}
+
+private fun createPerformance(
+    logger: Logger
+): Performance<CpuConfig, Watcher<CpuInfo>, CpuInfo> = CpuPerformance(
+    CpuWatcher(
+        defaultDispatcher = Dispatchers.Default,
+        mainDispatcher = Dispatchers.Main,
+        repository = CpuInfoRepositoryImpl(
+            cpuInfoMapper = CpuInfoMapper(),
+            procCpuInfoRawSource = ProcCpuInfoSource(),
+            shellCpuInfoRawSource = ShellCpuInfoSource(logger),
+        ),
+        logger
+    )
+)

--- a/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/repository/CpuInfoRepositoryImpl.kt
+++ b/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/repository/CpuInfoRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.smellouk.kamper.cpu.repository
+
+import android.os.Build
+import com.smellouk.kamper.cpu.CpuInfo
+import com.smellouk.kamper.cpu.repository.source.CpuInfoSource
+
+internal class CpuInfoRepositoryImpl(
+    private val procCpuInfoRawSource: CpuInfoSource,
+    private val shellCpuInfoRawSource: CpuInfoSource,
+    private val cpuInfoMapper: CpuInfoMapper
+) : CpuInfoRepository {
+    override fun getInfo(): CpuInfo {
+        val cpuInfoRaw = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            shellCpuInfoRawSource.getCpuInfoDto()
+        } else {
+            procCpuInfoRawSource.getCpuInfoDto()
+        }
+
+        return cpuInfoMapper.map(cpuInfoRaw)
+    }
+}

--- a/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/repository/source/CpuInfoSource.kt
+++ b/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/repository/source/CpuInfoSource.kt
@@ -1,0 +1,7 @@
+package com.smellouk.kamper.cpu.repository.source
+
+import com.smellouk.kamper.cpu.repository.CpuInfoDto
+
+internal interface CpuInfoSource {
+    fun getCpuInfoDto(): CpuInfoDto
+}

--- a/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/repository/source/ProcCpuInfoSource.kt
+++ b/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/repository/source/ProcCpuInfoSource.kt
@@ -1,0 +1,68 @@
+package com.smellouk.kamper.cpu.repository.source
+
+import android.os.Process
+import com.smellouk.kamper.cpu.repository.CpuInfoDto
+import java.io.BufferedReader
+import java.io.FileInputStream
+
+internal class ProcCpuInfoSource : CpuInfoSource {
+    private lateinit var cachedDto: CpuInfoDto
+
+    override fun getCpuInfoDto(): CpuInfoDto {
+        val pid = Process.myPid()
+        val currentCpuInfoRaw = parse(getCpuRateOfDevice(), getCpuRateOfApp(pid))
+
+        return if (!this::cachedDto.isInitialized) {
+            cachedDto = currentCpuInfoRaw
+            CpuInfoDto.INVALID
+        } else {
+            CpuInfoDto(
+                total = currentCpuInfoRaw.total - cachedDto.total,
+                idle = currentCpuInfoRaw.idle - cachedDto.idle,
+                app = currentCpuInfoRaw.app - cachedDto.app,
+                user = currentCpuInfoRaw.user - cachedDto.user,
+                system = currentCpuInfoRaw.system - cachedDto.system,
+                ioWait = currentCpuInfoRaw.ioWait - cachedDto.ioWait
+            )
+        }
+    }
+
+    private fun getCpuRateOfDevice(): String = FileInputStream("/proc/stat")
+        .bufferedReader()
+        .use(BufferedReader::readLine)
+
+    private fun getCpuRateOfApp(pid: Int): String = FileInputStream("/proc/$pid/stat")
+        .bufferedReader()
+        .use(BufferedReader::readLine)
+
+    @Suppress("MagicNumber")
+    private fun parse(
+        cpuRate: String,
+        pidCpuRate: String
+    ): CpuInfoDto {
+        val cpuInfoList = cpuRate.split("\\s+".toRegex())
+        check(cpuInfoList.size >= 9) { "Cpu info list size must be >= 9" }
+
+        val user = cpuInfoList[2].toFloat()
+        val nice = cpuInfoList[3].toFloat()
+        val system = cpuInfoList[4].toFloat()
+        val idle = cpuInfoList[5].toFloat()
+        val ioWait = cpuInfoList[6].toFloat()
+        val total = user + nice + system + idle + ioWait
+                + cpuInfoList[7].toFloat() + cpuInfoList[8].toFloat()
+        val pidCpuInfoList = pidCpuRate.split(" ")
+        check(pidCpuInfoList.size >= 17) { "Pid cpu info list size must be >= 17" }
+
+        val appCpuTime = pidCpuInfoList[13].toFloat() + pidCpuInfoList[14].toFloat() +
+                pidCpuInfoList[15].toFloat() + pidCpuInfoList[16].toFloat()
+
+        return CpuInfoDto(
+            user,
+            system,
+            idle,
+            ioWait,
+            total,
+            appCpuTime
+        )
+    }
+}

--- a/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/repository/source/ShellCpuInfoSource.kt
+++ b/kamper/modules/cpu/src/androidMain/kotlin/com/smellouk/kamper/cpu/repository/source/ShellCpuInfoSource.kt
@@ -1,0 +1,104 @@
+package com.smellouk.kamper.cpu.repository.source
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.cpu.repository.CpuInfoDto
+import java.io.InputStream
+import java.util.Locale
+
+internal class ShellCpuInfoSource(
+    private val logger: Logger
+) : CpuInfoSource {
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    override fun getCpuInfoDto(): CpuInfoDto {
+        var process: Process? = null
+        try {
+            process = Runtime.getRuntime().exec("top -n 1")
+            val cmdOutputLines = process?.inputStream?.readAllLine() ?: emptyList()
+            if (cmdOutputLines.isEmpty()) {
+                return CpuInfoDto.INVALID
+            }
+
+            var cpuTasksMap = emptyMap<String, Float>()
+            var cpuLabelIndex = -1
+            var cpuAppUsage = -1F
+            cmdOutputLines.forEach { line ->
+                if (line.isCpuTasksLine()) {
+                    cpuTasksMap = line.toCpuTasksMap()
+                }
+                if (line.isCpuLabelLine()) {
+                    cpuLabelIndex = line.toCPULabelIndex()
+                }
+                if (line.isCpuAppUsageLine()) {
+                    cpuAppUsage = line.getCpuAppUsage(cpuLabelIndex)
+                }
+            }
+
+            if (cpuTasksMap.isEmpty()) {
+                return CpuInfoDto.INVALID
+            }
+
+            val total = cpuTasksMap["cpu"]
+            val user = cpuTasksMap["user"]
+            val sys = cpuTasksMap["sys"]
+            val idle = cpuTasksMap["idle"]
+            val iow = cpuTasksMap["iow"]
+
+            return CpuInfoDto(
+                total = total.normalize(),
+                user = user.normalize(),
+                system = sys.normalize(),
+                idle = idle.normalize(),
+                ioWait = iow.normalize(),
+                app = cpuAppUsage.normalize()
+            )
+        } catch (e: Exception) {
+            logger.log(e.stackTraceToString())
+        } finally {
+            process?.destroy()
+        }
+
+        return CpuInfoDto.INVALID
+    }
+
+    private fun InputStream.readAllLine(): List<String> =
+        bufferedReader(Charsets.ISO_8859_1).useLines { lines ->
+            lines.filter { line ->
+                line.isNotBlank()
+            }.map { line ->
+                line.trim()
+            }
+                .toList()
+        }
+
+    private fun String.isCpuTasksLine(): Boolean = matches("^\\d+%\\w+.+\\d+%\\w+".toRegex())
+
+    private fun String.toCpuTasksMap(): Map<String, Float> = lowercase(Locale.US)
+        .split("\\s+".toRegex())
+        .map { cpuRaw -> cpuRaw.split("%") }
+        .filter { cpuItem -> cpuItem.size >= 2 }
+        .map { cpuItem -> cpuItem[1] to cpuItem[0].toFloat() }
+        .toMap()
+
+    private fun String.isCpuLabelLine(): Boolean = contains("CPU")
+
+    private fun String.toCPULabelIndex(): Int = this.split("\\s+".toRegex())
+        .indexOfFirst { element -> element.contains("CPU") }
+
+    private fun String.isCpuAppUsageLine(): Boolean =
+        startsWith(android.os.Process.myPid().toString())
+
+    private fun String.getCpuAppUsage(cpuIndex: Int): Float {
+        return split("\\s+".toRegex()).takeIf { params ->
+            params.isNotEmpty() && params.size >= cpuIndex
+        }?.elementAt(cpuIndex)?.toFloat() ?: -1F
+    }
+
+    private fun Float?.normalize(): Float = if (this == null || this < -1F) {
+        0F
+    } else {
+        this
+    }
+}

--- a/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/CpuConfig.kt
+++ b/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/CpuConfig.kt
@@ -1,0 +1,23 @@
+package com.smellouk.kamper.cpu
+
+import com.smellouk.kamper.api.Config
+import com.smellouk.kamper.api.EMPTY
+import com.smellouk.kamper.api.Logger
+
+data class CpuConfig(
+    override val isEnabled: Boolean,
+    override val intervalInMs: Long,
+    val logger: Logger
+) : Config {
+    companion object {
+        val DEFAULT = CpuConfig(true, 1000, Logger.EMPTY)
+    }
+
+    object Builder {
+        var isEnabled: Boolean = DEFAULT.isEnabled
+        var intervalInMs: Long = DEFAULT.intervalInMs
+        var logger: Logger = DEFAULT.logger
+
+        fun build(): CpuConfig = CpuConfig(isEnabled, intervalInMs, logger)
+    }
+}

--- a/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/CpuInfo.kt
+++ b/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/CpuInfo.kt
@@ -1,0 +1,15 @@
+package com.smellouk.kamper.cpu
+
+import com.smellouk.kamper.api.Info
+
+data class CpuInfo(
+    val totalUseRatio: Float,
+    val appRatio: Float,
+    val userRatio: Float,
+    val systemRatio: Float,
+    val ioWaitRatio: Float
+) : Info {
+    companion object {
+        val INVALID = CpuInfo(-1F, -1F, -1F, -1F, -1F)
+    }
+}

--- a/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/CpuPerformance.kt
+++ b/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/CpuPerformance.kt
@@ -1,0 +1,8 @@
+package com.smellouk.kamper.cpu
+
+import com.smellouk.kamper.api.Performance
+import com.smellouk.kamper.api.Watcher
+
+internal class CpuPerformance(
+    watcher: CpuWatcher,
+) : Performance<CpuConfig, Watcher<CpuInfo>, CpuInfo>(watcher)

--- a/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/CpuWatcher.kt
+++ b/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/CpuWatcher.kt
@@ -1,0 +1,13 @@
+package com.smellouk.kamper.cpu
+
+import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.api.Watcher
+import com.smellouk.kamper.cpu.repository.CpuInfoRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+internal class CpuWatcher(
+    defaultDispatcher: CoroutineDispatcher,
+    mainDispatcher: CoroutineDispatcher,
+    repository: CpuInfoRepository,
+    logger: Logger
+) : Watcher<CpuInfo>(defaultDispatcher, mainDispatcher, repository, logger)

--- a/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/Module.kt
+++ b/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/Module.kt
@@ -1,0 +1,5 @@
+package com.smellouk.kamper.cpu
+
+import com.smellouk.kamper.api.PerformanceModule
+
+expect val CpuModule: PerformanceModule<CpuConfig, CpuInfo>

--- a/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/repository/CpuInfoDto.kt
+++ b/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/repository/CpuInfoDto.kt
@@ -1,0 +1,16 @@
+package com.smellouk.kamper.cpu.repository
+
+data class CpuInfoDto(
+    var user: Float,
+    var system: Float,
+    var idle: Float,
+    var ioWait: Float,
+    var total: Float,
+    var app: Float
+) {
+    companion object {
+        val INVALID = CpuInfoDto(
+            -1F, -1F, -1F, -1F, -1F, -1F
+        )
+    }
+}

--- a/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/repository/CpuInfoMapper.kt
+++ b/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/repository/CpuInfoMapper.kt
@@ -1,0 +1,24 @@
+package com.smellouk.kamper.cpu.repository
+
+import com.smellouk.kamper.cpu.CpuInfo
+
+class CpuInfoMapper {
+    fun map(dto: CpuInfoDto): CpuInfo = if (dto == CpuInfoDto.INVALID) {
+        CpuInfo.INVALID
+    } else {
+        with(dto) {
+            val totalTime = total * 1F
+            if (totalTime <= 0) {
+                return@with CpuInfo.INVALID
+            }
+
+            CpuInfo(
+                totalUseRatio = (totalTime - idle) / totalTime,
+                appRatio = app / totalTime,
+                userRatio = user / totalTime,
+                systemRatio = system / totalTime,
+                ioWaitRatio = ioWait / totalTime
+            )
+        }
+    }
+}

--- a/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/repository/CpuInfoRepository.kt
+++ b/kamper/modules/cpu/src/commonMain/kotlin/com/smellouk/kamper/cpu/repository/CpuInfoRepository.kt
@@ -1,0 +1,6 @@
+package com.smellouk.kamper.cpu.repository
+
+import com.smellouk.kamper.api.InfoRepository
+import com.smellouk.kamper.cpu.CpuInfo
+
+interface CpuInfoRepository : InfoRepository<CpuInfo>

--- a/samples/android/src/main/java/com/smellouk/kamper/samples/MainActivity.kt
+++ b/samples/android/src/main/java/com/smellouk/kamper/samples/MainActivity.kt
@@ -2,10 +2,40 @@ package com.smellouk.kamper.samples
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
+import com.smellouk.kamper.Kamper
+import com.smellouk.kamper.api.DEFAULT
+import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.cpu.CpuInfo
+import com.smellouk.kamper.cpu.CpuModule
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        lifecycle.addObserver(Kamper)
+
+        Kamper.setup {
+            logger = Logger.DEFAULT
+        }.apply {
+            install(
+                CpuModule {
+                    isEnabled = true
+                    intervalInMs = 1000
+                    logger = Logger.DEFAULT
+                }
+            )
+            // Quick start default(isEnabled=true, intervalInMs=1000, logger=Logger.EMPTY)
+            // install(CpuModule)
+
+            addInfoListener<CpuInfo> { cpuInfo ->
+                if (cpuInfo != CpuInfo.INVALID) {
+                    Log.i("Samples", cpuInfo.toString())
+                } else {
+                    Log.i("Samples", "CPU info is invalid")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
resolves #6

<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
Implemented CPU performance module for android. To performance, calculation rely on api level to calculate the CPU performance. 
When api level is > 26: We use shell command `top -n 1` then we parse the result. 
When api level is <= 26: We read cpu info from [proc file](https://www.kernel.org/doc/html/latest/filesystems/proc.html). (We can't use proc file reading on Android O.)

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
To monitor CPU performance when the target app is running. 

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Run `sampples.android` on device +26 and device -26
You should see:
```
2021-12-28 04:08:19.397 3055-3055/com.smellouk.kamper.samples I/Kamper: CpuInfo(totalUseRatio=0.9997775, appRatio=8.750723E-4, userRatio=0.0011865387, systemRatio=0.9935927, ioWaitRatio=0.0)
2021-12-28 04:08:20.402 3055-3055/com.smellouk.kamper.samples I/Kamper: CpuInfo(totalUseRatio=0.99977887, appRatio=8.846426E-4, userRatio=0.0011795234, systemRatio=0.9936011, ioWaitRatio=0.0)
```
## ✅ Checklist
<!--- Just put an `x` in all the boxes that apply. -->
- [x] My code follows our [contribution guide](https://github.com/smellouk/kamper/blob/develop/CONTRIBUTING.md).
- [ ] I have added unit tests to cover the changes.
- [x] I have used and tested this on my device(s).
- [x] I have cleaned commit history.
- [ ] I have updated [README.md](https://github.com/smellouk/kamper/blob/develop/README.md) (if applicable)
