### PR TITLE
#7 🌟 Implement FPS performance module

### DIFF
--- a/kamper/api/src/commonMain/kotlin/com/smellouk/kamper/api/Extensions.kt
+++ b/kamper/api/src/commonMain/kotlin/com/smellouk/kamper/api/Extensions.kt
@@ -4,4 +4,7 @@ fun Long.toMb(): Float {
     return this / KILO / KILO
 }
 
+fun Long.millisToSeconds(): Double = this / MILLIS_TO_SECONDS_UNIT
+
 private const val KILO = 1024F
+private const val MILLIS_TO_SECONDS_UNIT = 1000000000.0

--- a/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/FpsPerformance.kt
+++ b/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/FpsPerformance.kt
@@ -1,0 +1,19 @@
+package com.smellouk.kamper.fps
+
+import com.smellouk.kamper.api.Performance
+import com.smellouk.kamper.api.Watcher
+import com.smellouk.kamper.fps.repository.source.FpsChoreographer
+
+internal actual class FpsPerformance actual constructor(
+    watcher: FpsWatcher
+) : Performance<FpsConfig, Watcher<FpsInfo>, FpsInfo>(watcher) {
+    override fun start() {
+        super.start()
+        FpsChoreographer.start()
+    }
+
+    override fun stop() {
+        super.stop()
+        FpsChoreographer.stop()
+    }
+}

--- a/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/Module.kt
+++ b/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/Module.kt
@@ -1,0 +1,42 @@
+package com.smellouk.kamper.fps
+
+import com.smellouk.kamper.api.KamperDslMarker
+import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.api.Performance
+import com.smellouk.kamper.api.PerformanceModule
+import com.smellouk.kamper.api.Watcher
+import com.smellouk.kamper.fps.repository.FpsInfoMapper
+import com.smellouk.kamper.fps.repository.FpsInfoRepositoryImpl
+import com.smellouk.kamper.fps.repository.source.FpsChoreographer
+import com.smellouk.kamper.fps.repository.source.FpsInfoSource
+import kotlinx.coroutines.Dispatchers
+
+actual val FpsModule: PerformanceModule<FpsConfig, FpsInfo> = PerformanceModule(
+    config = FpsConfig.DEFAULT,
+    performance = createPerformance(FpsConfig.DEFAULT.logger)
+)
+
+@KamperDslMarker
+@Suppress("FunctionNaming")
+fun FpsModule(
+    builder: FpsConfig.Builder.() -> Unit
+): PerformanceModule<FpsConfig, FpsInfo> = with(FpsConfig.Builder.apply(builder).build()) {
+    PerformanceModule(
+        config = this,
+        performance = createPerformance(logger)
+    )
+}
+
+private fun createPerformance(
+    logger: Logger
+): Performance<FpsConfig, Watcher<FpsInfo>, FpsInfo> = FpsPerformance(
+    FpsWatcher(
+        defaultDispatcher = Dispatchers.Default,
+        mainDispatcher = Dispatchers.Main,
+        repository = FpsInfoRepositoryImpl(
+            fpsInfoMapper = FpsInfoMapper(),
+            fpsSource = FpsInfoSource(FpsChoreographer),
+        ),
+        logger = logger
+    )
+)

--- a/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/repository/FpsInfoRepositoryImpl.kt
+++ b/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/repository/FpsInfoRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.smellouk.kamper.fps.repository
+
+import com.smellouk.kamper.fps.FpsInfo
+import com.smellouk.kamper.fps.repository.source.FpsInfoSource
+
+internal class FpsInfoRepositoryImpl(
+    private val fpsSource: FpsInfoSource,
+    private val fpsInfoMapper: FpsInfoMapper
+) : FpsInfoRepository {
+    override fun getInfo(): FpsInfo =
+        fpsInfoMapper.map(fpsSource.getFpsInfoRaw())
+}

--- a/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/repository/source/FpsChoreographer.kt
+++ b/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/repository/source/FpsChoreographer.kt
@@ -1,0 +1,28 @@
+package com.smellouk.kamper.fps.repository.source
+
+import android.view.Choreographer
+
+internal object FpsChoreographer {
+    private var choreographer: Choreographer? = null
+    private val callback = object : Choreographer.FrameCallback {
+        override fun doFrame(frameTimeNanos: Long) {
+            doFrameListener?.invoke(frameTimeNanos)
+            choreographer?.postFrameCallback(this)
+        }
+    }
+    private var doFrameListener: ((Long) -> Unit)? = null
+
+    fun setDoFrameListener(listener: ((Long) -> Unit)?) {
+        doFrameListener = listener
+    }
+
+    fun start() {
+        choreographer = Choreographer.getInstance()
+        choreographer?.postFrameCallback(callback)
+    }
+
+    fun stop() {
+        choreographer?.removeFrameCallback(callback)
+        choreographer = null
+    }
+}

--- a/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/repository/source/FpsInfoSource.kt
+++ b/kamper/modules/fps/src/androidMain/kotlin/com/smellouk/kamper/fps/repository/source/FpsInfoSource.kt
@@ -1,0 +1,32 @@
+package com.smellouk.kamper.fps.repository.source
+
+import com.smellouk.kamper.api.millisToSeconds
+import com.smellouk.kamper.fps.repository.FpsInfoDto
+
+internal class FpsInfoSource(choreographer: FpsChoreographer) {
+    private var currentFrameCount: Int = 0
+    private var startFrameTimeNanos: Long = 0
+    private var currentFrameTimeNanos: Long = 0
+
+    init {
+        choreographer.setDoFrameListener { frameTimeNanos ->
+            currentFrameCount++
+            if (startFrameTimeNanos == 0L) {
+                startFrameTimeNanos = frameTimeNanos
+            }
+            currentFrameTimeNanos = frameTimeNanos
+        }
+    }
+
+    fun getFpsInfoRaw(): FpsInfoDto {
+        val fpsInfo = FpsInfoDto(
+            currentFrameCount = currentFrameCount,
+            startFrameTimeInSeconds = startFrameTimeNanos.millisToSeconds(),
+            currentFrameTimeInSeconds = currentFrameTimeNanos.millisToSeconds()
+        )
+        startFrameTimeNanos = 0
+        currentFrameTimeNanos = 0
+        currentFrameCount = 0
+        return fpsInfo
+    }
+}

--- a/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/FpsConfig.kt
+++ b/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/FpsConfig.kt
@@ -1,0 +1,25 @@
+package com.smellouk.kamper.fps
+
+import com.smellouk.kamper.api.Config
+import com.smellouk.kamper.api.EMPTY
+import com.smellouk.kamper.api.Logger
+
+data class FpsConfig(
+    override val isEnabled: Boolean,
+    val logger: Logger
+) : Config {
+    override val intervalInMs: Long = ONE_SECOND_IN_MILLIS
+
+    companion object {
+        val DEFAULT = FpsConfig(true, Logger.EMPTY)
+    }
+
+    object Builder {
+        var isEnabled: Boolean = DEFAULT.isEnabled
+        var logger: Logger = DEFAULT.logger
+
+        fun build(): FpsConfig = FpsConfig(isEnabled, logger)
+    }
+}
+
+private const val ONE_SECOND_IN_MILLIS = 1000L

--- a/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/FpsInfo.kt
+++ b/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/FpsInfo.kt
@@ -1,0 +1,9 @@
+package com.smellouk.kamper.fps
+
+import com.smellouk.kamper.api.Info
+
+data class FpsInfo(val fps: Int) : Info {
+    companion object {
+        val INVALID = FpsInfo(-1)
+    }
+}

--- a/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/FpsPerformance.kt
+++ b/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/FpsPerformance.kt
@@ -1,0 +1,8 @@
+package com.smellouk.kamper.fps
+
+import com.smellouk.kamper.api.Performance
+import com.smellouk.kamper.api.Watcher
+
+internal expect class FpsPerformance(
+    watcher: FpsWatcher
+) : Performance<FpsConfig, Watcher<FpsInfo>, FpsInfo>

--- a/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/FpsWatcher.kt
+++ b/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/FpsWatcher.kt
@@ -1,0 +1,13 @@
+package com.smellouk.kamper.fps
+
+import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.api.Watcher
+import com.smellouk.kamper.fps.repository.FpsInfoRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+internal class FpsWatcher(
+    defaultDispatcher: CoroutineDispatcher,
+    mainDispatcher: CoroutineDispatcher,
+    repository: FpsInfoRepository,
+    logger: Logger
+) : Watcher<FpsInfo>(defaultDispatcher, mainDispatcher, repository, logger)

--- a/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/Module.kt
+++ b/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/Module.kt
@@ -1,0 +1,5 @@
+package com.smellouk.kamper.fps
+
+import com.smellouk.kamper.api.PerformanceModule
+
+expect val FpsModule: PerformanceModule<FpsConfig, FpsInfo>

--- a/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/repository/FpsInfoDto.kt
+++ b/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/repository/FpsInfoDto.kt
@@ -1,0 +1,15 @@
+package com.smellouk.kamper.fps.repository
+
+internal class FpsInfoDto(
+    val currentFrameCount: Int,
+    val startFrameTimeInSeconds: Double,
+    val currentFrameTimeInSeconds: Double
+) {
+    companion object {
+        val INVALID = FpsInfoDto(
+            -1,
+            -1.0,
+            -1.0
+        )
+    }
+}

--- a/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/repository/FpsInfoMapper.kt
+++ b/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/repository/FpsInfoMapper.kt
@@ -1,0 +1,17 @@
+package com.smellouk.kamper.fps.repository
+
+import com.smellouk.kamper.fps.FpsInfo
+import kotlin.math.roundToInt
+
+internal class FpsInfoMapper {
+    fun map(dto: FpsInfoDto): FpsInfo = with(dto) {
+        if (this == FpsInfoDto.INVALID) {
+            return FpsInfo.INVALID
+        }
+        if (currentFrameCount < 1 || currentFrameTimeInSeconds < startFrameTimeInSeconds) {
+            return FpsInfo.INVALID
+        }
+        val fps = currentFrameCount / (currentFrameTimeInSeconds - startFrameTimeInSeconds)
+        return FpsInfo(fps.roundToInt() - 1)
+    }
+}

--- a/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/repository/FpsInfoRepository.kt
+++ b/kamper/modules/fps/src/commonMain/kotlin/com/smellouk/kamper/fps/repository/FpsInfoRepository.kt
@@ -1,0 +1,6 @@
+package com.smellouk.kamper.fps.repository
+
+import com.smellouk.kamper.api.InfoRepository
+import com.smellouk.kamper.fps.FpsInfo
+
+internal interface FpsInfoRepository : InfoRepository<FpsInfo>

--- a/samples/android/src/main/java/com/smellouk/kamper/samples/MainActivity.kt
+++ b/samples/android/src/main/java/com/smellouk/kamper/samples/MainActivity.kt
@@ -8,6 +8,8 @@ import com.smellouk.kamper.api.DEFAULT
 import com.smellouk.kamper.api.Logger
 import com.smellouk.kamper.cpu.CpuInfo
 import com.smellouk.kamper.cpu.CpuModule
+import com.smellouk.kamper.fps.FpsInfo
+import com.smellouk.kamper.fps.FpsModule
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,11 +31,28 @@ class MainActivity : AppCompatActivity() {
             // Quick start default(isEnabled=true, intervalInMs=1000, logger=Logger.EMPTY)
             // install(CpuModule)
 
+            install(
+                FpsModule {
+                    isEnabled = true
+                    logger = Logger.DEFAULT
+                }
+            )
+            // Quick start default(isEnabled=true, logger=Logger.EMPTY)
+            // install(FpsModule)
+
             addInfoListener<CpuInfo> { cpuInfo ->
                 if (cpuInfo != CpuInfo.INVALID) {
                     Log.i("Samples", cpuInfo.toString())
                 } else {
                     Log.i("Samples", "CPU info is invalid")
+                }
+            }
+
+            addInfoListener<FpsInfo> { fpsInfo ->
+                if (fpsInfo != FpsInfo.INVALID) {
+                    Log.i("Samples", fpsInfo.toString())
+                } else {
+                    Log.i("Samples", "FPS info is invalid")
                 }
             }
         }


### PR DESCRIPTION
resolves #7

<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
Implemented FPS performance module. The FPS calculation is done based on the choreographer, with a loop of 1 second. 
The lifecycle of the choreographer is bound to the lifecycle of the performance. 

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
To monitor app FPS. 

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Run `sampples.android` on device +26 and device -26
You should see:
```
2021-12-28 04:45:59.616 3827-3847/com.smellouk.kamper.samples I/Kamper: FpsInfo(fps=60)
```

## ✅ Checklist
<!--- Just put an `x` in all the boxes that apply. -->
- [x] My code follows our [contribution guide](https://github.com/smellouk/kamper/blob/develop/CONTRIBUTING.md).
- [ ] I have added unit tests to cover the changes.
- [x] I have used and tested this on my device(s).
- [x] I have cleaned commit history.
- [ ] I have updated [README.md](https://github.com/smellouk/kamper/blob/develop/README.md) (if applicable)