### PR TITLE
#8 🌟 Implement memory performance module

### DIFF
--- a/kamper/modules/memory/src/androidMain/kotlin/com/smellouk/kamper/memory/Module.kt
+++ b/kamper/modules/memory/src/androidMain/kotlin/com/smellouk/kamper/memory/Module.kt
@@ -1,0 +1,39 @@
+package com.smellouk.kamper.memory
+
+import android.content.Context
+import com.smellouk.kamper.api.KamperDslMarker
+import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.api.Performance
+import com.smellouk.kamper.api.PerformanceModule
+import com.smellouk.kamper.api.Watcher
+import com.smellouk.kamper.memory.repository.MemoryInfoMapper
+import com.smellouk.kamper.memory.repository.MemoryInfoRepositoryImpl
+import com.smellouk.kamper.memory.repository.source.MemoryInfoSource
+import kotlinx.coroutines.Dispatchers
+
+@KamperDslMarker
+@Suppress("FunctionNaming")
+fun MemoryModule(
+    context: Context,
+    builder: MemoryConfig.Builder.() -> Unit = MemoryConfig.Builder.DEFAULT_ACTION
+): PerformanceModule<MemoryConfig, MemoryInfo> = with(MemoryConfig.Builder.DEFAULT.apply(builder).build()) {
+    PerformanceModule(
+        config = this,
+        performance = createPerformance(context, logger)
+    )
+}
+
+private fun createPerformance(
+    context: Context,
+    logger: Logger
+): Performance<MemoryConfig, Watcher<MemoryInfo>, MemoryInfo> = MemoryPerformance(
+    MemoryWatcher(
+        defaultDispatcher = Dispatchers.Default,
+        mainDispatcher = Dispatchers.Main,
+        repository = MemoryInfoRepositoryImpl(
+            memorySource = MemoryInfoSource(context, logger),
+            memoryInfoMapper = MemoryInfoMapper(),
+        ),
+        logger = logger
+    )
+)

--- a/kamper/modules/memory/src/androidMain/kotlin/com/smellouk/kamper/memory/repository/MemoryInfoRepositoryImpl.kt
+++ b/kamper/modules/memory/src/androidMain/kotlin/com/smellouk/kamper/memory/repository/MemoryInfoRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.smellouk.kamper.memory.repository
+
+import com.smellouk.kamper.memory.MemoryInfo
+import com.smellouk.kamper.memory.repository.source.MemoryInfoSource
+
+internal class MemoryInfoRepositoryImpl(
+    private val memorySource: MemoryInfoSource,
+    private val memoryInfoMapper: MemoryInfoMapper
+) : MemoryInfoRepository {
+    override fun getInfo(): MemoryInfo =
+        memoryInfoMapper.map(memorySource.getMemoryInfoDto())
+}

--- a/kamper/modules/memory/src/androidMain/kotlin/com/smellouk/kamper/memory/repository/source/MemoryInfoSource.kt
+++ b/kamper/modules/memory/src/androidMain/kotlin/com/smellouk/kamper/memory/repository/source/MemoryInfoSource.kt
@@ -1,0 +1,50 @@
+package com.smellouk.kamper.memory.repository.source
+
+import android.app.ActivityManager
+import android.content.Context
+import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.memory.repository.MemoryInfoDto
+
+internal class MemoryInfoSource(
+    context: Context?,
+    private val logger: Logger
+) {
+    private val activityManager: ActivityManager? =
+        context?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager?
+
+    fun getMemoryInfoDto(): MemoryInfoDto {
+        if (activityManager == null) {
+            return MemoryInfoDto.INVALID
+        }
+
+        return try {
+            val runtime = Runtime.getRuntime()
+            val pssInfo = activityManager.getProcessMemoryInfo(
+                intArrayOf(android.os.Process.myPid())
+            ).firstOrNull()
+
+            val ramInfo = ActivityManager.MemoryInfo()
+            activityManager.getMemoryInfo(ramInfo)
+
+            MemoryInfoDto(
+                // App
+                freeMemoryInBytes = runtime.freeMemory(),
+                maxMemoryInBytes = runtime.maxMemory(),
+                allocatedInBytes = runtime.totalMemory() - runtime.freeMemory(),
+                // PSS
+                totalPssInBytes = pssInfo?.totalPss?.toLong(),
+                dalvikPssInBytes = pssInfo?.dalvikPss?.toLong(),
+                nativePssInBytes = pssInfo?.nativePss?.toLong(),
+                otherPssInBytes = pssInfo?.otherPss?.toLong(),
+                // Ram
+                availableRamInBytes = ramInfo.availMem,
+                totalRamInBytes = ramInfo.totalMem,
+                lowRamThresholdInBytes = ramInfo.threshold,
+                isLowMemory = ramInfo.lowMemory
+            )
+        } catch (e: Exception) {
+            logger.log(e.stackTraceToString())
+            MemoryInfoDto.INVALID
+        }
+    }
+}

--- a/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/MemoryConfig.kt
+++ b/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/MemoryConfig.kt
@@ -1,0 +1,28 @@
+package com.smellouk.kamper.memory
+
+import com.smellouk.kamper.api.Config
+import com.smellouk.kamper.api.EMPTY
+import com.smellouk.kamper.api.Logger
+
+class MemoryConfig(
+    override val isEnabled: Boolean,
+    override val intervalInMs: Long,
+    val logger: Logger
+) : Config {
+    companion object {
+        val DEFAULT = MemoryConfig(true, 1000, Logger.EMPTY)
+    }
+
+    class Builder {
+        companion object {
+            val DEFAULT_ACTION: Builder.() -> Unit = {}
+            val DEFAULT: Builder = Builder()
+        }
+
+        var intervalInMs: Long = MemoryConfig.DEFAULT.intervalInMs
+        var isEnabled: Boolean = MemoryConfig.DEFAULT.isEnabled
+        var logger: Logger = MemoryConfig.DEFAULT.logger
+
+        fun build(): MemoryConfig = MemoryConfig(isEnabled, intervalInMs, logger)
+    }
+}

--- a/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/MemoryInfo.kt
+++ b/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/MemoryInfo.kt
@@ -1,0 +1,53 @@
+package com.smellouk.kamper.memory
+
+import com.smellouk.kamper.api.Info
+
+data class MemoryInfo(
+    val appMemoryInfo: AppMemoryInfo,
+    val pssInfo: PssInfo,
+    val ramInfo: RamInfo
+) : Info {
+    companion object {
+        val INVALID = MemoryInfo(
+            AppMemoryInfo.INVALID, PssInfo.INVALID, RamInfo.INVALID
+        )
+    }
+
+    data class AppMemoryInfo(
+        val freeMemoryInMb: Float,
+        val maxMemoryInMb: Float,
+        val allocatedInMb: Float
+    ) {
+        companion object {
+            val INVALID = AppMemoryInfo(
+                -1F, -1F, -1F
+            )
+        }
+    }
+
+    data class PssInfo(
+        val totalPssInMb: Float,
+        val dalvikPssInMb: Float,
+        val nativePssInMb: Float,
+        val otherPssInMb: Float
+    ) {
+        companion object {
+            val INVALID = PssInfo(
+                -1F, -1F, -1F, -1F
+            )
+        }
+    }
+
+    data class RamInfo(
+        val availableRamInMb: Float,
+        val totalRamInMb: Float,
+        val lowRamThresholdInMb: Float,
+        val isLowMemory: Boolean
+    ) {
+        companion object {
+            val INVALID = RamInfo(
+                -1F, -1F, -1F, false
+            )
+        }
+    }
+}

--- a/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/MemoryPerformance.kt
+++ b/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/MemoryPerformance.kt
@@ -1,0 +1,8 @@
+package com.smellouk.kamper.memory
+
+import com.smellouk.kamper.api.Performance
+import com.smellouk.kamper.api.Watcher
+
+internal class MemoryPerformance(
+    watcher: MemoryWatcher
+) : Performance<MemoryConfig, Watcher<MemoryInfo>, MemoryInfo>(watcher)

--- a/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/MemoryWatcher.kt
+++ b/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/MemoryWatcher.kt
@@ -1,0 +1,13 @@
+package com.smellouk.kamper.memory
+
+import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.api.Watcher
+import com.smellouk.kamper.memory.repository.MemoryInfoRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+internal class MemoryWatcher(
+    defaultDispatcher: CoroutineDispatcher,
+    mainDispatcher: CoroutineDispatcher,
+    repository: MemoryInfoRepository,
+    logger: Logger
+) : Watcher<MemoryInfo>(defaultDispatcher, mainDispatcher, repository, logger)

--- a/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/repository/MemoryInfoDto.kt
+++ b/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/repository/MemoryInfoDto.kt
@@ -1,0 +1,33 @@
+package com.smellouk.kamper.memory.repository
+
+data class MemoryInfoDto(
+    val freeMemoryInBytes: Long,
+    val maxMemoryInBytes: Long,
+    val allocatedInBytes: Long,
+
+    val totalPssInBytes: Long?,
+    val dalvikPssInBytes: Long?,
+    val nativePssInBytes: Long?,
+    val otherPssInBytes: Long?,
+
+    val availableRamInBytes: Long,
+    val totalRamInBytes: Long,
+    val lowRamThresholdInBytes: Long,
+    val isLowMemory: Boolean
+) {
+    companion object {
+        val INVALID = MemoryInfoDto(
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            false
+        )
+    }
+}

--- a/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/repository/MemoryInfoMapper.kt
+++ b/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/repository/MemoryInfoMapper.kt
@@ -1,0 +1,35 @@
+package com.smellouk.kamper.memory.repository
+
+import com.smellouk.kamper.api.toMb
+import com.smellouk.kamper.memory.MemoryInfo
+import com.smellouk.kamper.memory.MemoryInfo.AppMemoryInfo
+import com.smellouk.kamper.memory.MemoryInfo.PssInfo
+import com.smellouk.kamper.memory.MemoryInfo.RamInfo
+
+class MemoryInfoMapper {
+    fun map(dto: MemoryInfoDto): MemoryInfo = if (dto == MemoryInfoDto.INVALID) {
+        MemoryInfo.INVALID
+    } else {
+        with(dto) {
+            MemoryInfo(
+                appMemoryInfo = AppMemoryInfo(
+                    freeMemoryInMb = freeMemoryInBytes.toMb(),
+                    maxMemoryInMb = maxMemoryInBytes.toMb(),
+                    allocatedInMb = allocatedInBytes.toMb(),
+                ),
+                pssInfo = PssInfo(
+                    totalPssInMb = totalPssInBytes?.toMb() ?: -1F,
+                    dalvikPssInMb = dalvikPssInBytes?.toMb() ?: -1F,
+                    nativePssInMb = nativePssInBytes?.toMb() ?: -1F,
+                    otherPssInMb = otherPssInBytes?.toMb() ?: -1F
+                ),
+                ramInfo = RamInfo(
+                    availableRamInMb = availableRamInBytes.toMb(),
+                    totalRamInMb = totalRamInBytes.toMb(),
+                    lowRamThresholdInMb = lowRamThresholdInBytes.toMb(),
+                    isLowMemory = isLowMemory
+                )
+            )
+        }
+    }
+}

--- a/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/repository/MemoryInfoRepository.kt
+++ b/kamper/modules/memory/src/commonMain/kotlin/com/smellouk/kamper/memory/repository/MemoryInfoRepository.kt
@@ -1,0 +1,6 @@
+package com.smellouk.kamper.memory.repository
+
+import com.smellouk.kamper.api.InfoRepository
+import com.smellouk.kamper.memory.MemoryInfo
+
+interface MemoryInfoRepository : InfoRepository<MemoryInfo>

--- a/samples/android/src/main/java/com/smellouk/kamper/samples/MainActivity.kt
+++ b/samples/android/src/main/java/com/smellouk/kamper/samples/MainActivity.kt
@@ -6,10 +6,13 @@ import android.util.Log
 import com.smellouk.kamper.Kamper
 import com.smellouk.kamper.api.DEFAULT
 import com.smellouk.kamper.api.Logger
+import com.smellouk.kamper.cpu.CpuConfig
 import com.smellouk.kamper.cpu.CpuInfo
 import com.smellouk.kamper.cpu.CpuModule
 import com.smellouk.kamper.fps.FpsInfo
 import com.smellouk.kamper.fps.FpsModule
+import com.smellouk.kamper.memory.MemoryInfo
+import com.smellouk.kamper.memory.MemoryModule
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -40,6 +43,14 @@ class MainActivity : AppCompatActivity() {
             // Quick start default(isEnabled=true, logger=Logger.EMPTY)
             // install(FpsModule)
 
+            install(
+                MemoryModule(applicationContext) {
+                    isEnabled = true
+                    intervalInMs = 1000
+                    logger = Logger.DEFAULT
+                }
+            )
+
             addInfoListener<CpuInfo> { cpuInfo ->
                 if (cpuInfo != CpuInfo.INVALID) {
                     Log.i("Samples", cpuInfo.toString())
@@ -51,6 +62,14 @@ class MainActivity : AppCompatActivity() {
             addInfoListener<FpsInfo> { fpsInfo ->
                 if (fpsInfo != FpsInfo.INVALID) {
                     Log.i("Samples", fpsInfo.toString())
+                } else {
+                    Log.i("Samples", "FPS info is invalid")
+                }
+            }
+
+            addInfoListener<MemoryInfo> { memoryInfo ->
+                if (memoryInfo != MemoryInfo.INVALID) {
+                    Log.i("Samples", memoryInfo.toString())
                 } else {
                     Log.i("Samples", "FPS info is invalid")
                 }


### PR DESCRIPTION
resolves #8

<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
Implemented memory performance module, the module relies on context to extract memory info. 
The implementation extracts: Memory Info for the app, memory info for the device and PSS info. 
All implementation relies on `ActivityManager.getProcessMemoryInfo`. 

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
To monitory memory usage. 

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Run `sampples.android` on device +26 and device -26
You should see:
```
2021-12-28 12:57:02.647 4275-4294/com.smellouk.kamper.samples I/Kamper: MemoryInfo(appMemoryInfo=AppMemoryInfo(freeMemoryInMb=2.5756845, maxMemoryInMb=384.0, allocatedInMb=12.486648), pssInfo=PssInfo(totalPssInMb=0.01783657, dalvikPssInMb=0.00442791, nativePssInMb=0.0031776428, otherPssInMb=0.010231018), ramInfo=RamInfo(availableRamInMb=1158.6719, totalRamInMb=1499.0195, lowRamThresholdInMb=216.0, isLowMemory=false))
```

## ✅ Checklist
<!--- Just put an `x` in all the boxes that apply. -->
- [x] My code follows our [contribution guide](https://github.com/smellouk/kamper/blob/develop/CONTRIBUTING.md).
- [ ] I have added unit tests to cover the changes.
- [x] I have used and tested this on my device(s).
- [x] I have cleaned commit history.
- [ ] I have updated [README.md](https://github.com/smellouk/kamper/blob/develop/README.md) (if applicable)