### PR TITLE
#26 🐛 Fix network info for android devices < 23api

### DIFF
--- a/kamper/modules/network/src/androidMain/kotlin/com/smellouk/kamper/network/Module.kt
+++ b/kamper/modules/network/src/androidMain/kotlin/com/smellouk/kamper/network/Module.kt
@@ -34,7 +34,7 @@ private fun createPerformance(
         defaultDispatcher = Dispatchers.Default,
         mainDispatcher = Dispatchers.Main,
         repository = NetworkInfoRepositoryImpl(
-            networkInfoSource = NetworkInfoSource(),
+            networkInfoSource = NetworkInfoSource(logger),
             networkInfoMapper = NetworkInfoMapper()
         ),
         logger = logger

--- a/kamper/modules/network/src/androidMain/kotlin/com/smellouk/kamper/network/repository/source/NetworkInfoSource.kt
+++ b/kamper/modules/network/src/androidMain/kotlin/com/smellouk/kamper/network/repository/source/NetworkInfoSource.kt
@@ -2,9 +2,10 @@ package com.smellouk.kamper.network.repository.source
 
 import android.net.TrafficStats
 import android.os.Process
+import com.smellouk.kamper.api.Logger
 import com.smellouk.kamper.network.repository.NetworkInfoDto
 
-internal class NetworkInfoSource {
+internal class NetworkInfoSource(private val logger: Logger) {
     // Visible only for testing
     internal lateinit var cachedDto: NetworkInfoDto
     fun getNetworkInfoDto(): NetworkInfoDto {
@@ -15,6 +16,13 @@ internal class NetworkInfoSource {
             txUidInBytes = TrafficStats.getUidTxBytes(Process.myUid())
         )
 
+        if (currentDto == NetworkInfoDto.INVALID) {
+            logger.log(
+                "TrafficStats is returning -1, maybe your device does not " +
+                        "support TrafficStats or min required api <23 "
+            )
+            return NetworkInfoDto.NOT_SUPPORTED
+        }
         return if (!this::cachedDto.isInitialized) {
             cachedDto = currentDto
             NetworkInfoDto.INVALID

--- a/kamper/modules/network/src/androidTest/kotlin/com/smellouk/kamper/network/repository/source/NetworkInfoSourceTest.kt
+++ b/kamper/modules/network/src/androidTest/kotlin/com/smellouk/kamper/network/repository/source/NetworkInfoSourceTest.kt
@@ -4,6 +4,7 @@ import android.net.TrafficStats
 import android.os.Process
 import com.smellouk.kamper.network.repository.NetworkInfoDto
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.junit.After
@@ -12,7 +13,7 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 class NetworkInfoSourceTest {
-    private val classToTest = NetworkInfoSource()
+    private val classToTest = NetworkInfoSource(mockk(relaxed = true))
 
     @Before
     fun setup() {
@@ -38,6 +39,15 @@ class NetworkInfoSourceTest {
     }
 
     @Test
+    fun `getNetworkInfoDto should return not supported dto when device does not supports TrafficStats`() {
+        mockTraffic(NOT_SUPPORTED)
+
+        val dto = classToTest.getNetworkInfoDto()
+
+        assertEquals(NetworkInfoDto.NOT_SUPPORTED, dto)
+    }
+
+    @Test
     fun `getNetworkInfoDto should return valid dto when cache is available`() {
         classToTest.cachedDto = CACHED_DTO
         mockTraffic(ONE_MEGABYTE_TRAFFIC_IN_BYTES * 3)
@@ -57,6 +67,7 @@ class NetworkInfoSourceTest {
 
 private const val MY_UUID = 128797234
 private const val ONE_MEGABYTE_TRAFFIC_IN_BYTES = 1024 * 1024L
+private const val NOT_SUPPORTED = -1L
 
 private val CACHED_DTO = NetworkInfoDto(
     rxTotalInBytes = ONE_MEGABYTE_TRAFFIC_IN_BYTES,

--- a/kamper/modules/network/src/commonMain/kotlin/com/smellouk/kamper/network/NetworkInfo.kt
+++ b/kamper/modules/network/src/commonMain/kotlin/com/smellouk/kamper/network/NetworkInfo.kt
@@ -12,5 +12,8 @@ data class NetworkInfo(
         val INVALID = NetworkInfo(
             -1F, -1F, -1F, -1F
         )
+        val NOT_SUPPORTED = NetworkInfo(
+            -100F, -100F, -100F, -100F
+        )
     }
 }

--- a/kamper/modules/network/src/commonMain/kotlin/com/smellouk/kamper/network/repository/NetworkInfoDto.kt
+++ b/kamper/modules/network/src/commonMain/kotlin/com/smellouk/kamper/network/repository/NetworkInfoDto.kt
@@ -13,5 +13,11 @@ internal data class NetworkInfoDto(
             -1,
             -1,
         )
+        val NOT_SUPPORTED = NetworkInfoDto(
+            -100,
+            -100,
+            -100,
+            -100,
+        )
     }
 }

--- a/kamper/modules/network/src/commonMain/kotlin/com/smellouk/kamper/network/repository/NetworkInfoMapper.kt
+++ b/kamper/modules/network/src/commonMain/kotlin/com/smellouk/kamper/network/repository/NetworkInfoMapper.kt
@@ -6,16 +6,22 @@ import com.smellouk.kamper.network.NetworkInfo
 internal class NetworkInfoMapper {
     fun map(
         dto: NetworkInfoDto
-    ): NetworkInfo = if (dto == NetworkInfoDto.INVALID) {
-        NetworkInfo.INVALID
-    } else {
-        with(dto) {
-            NetworkInfo(
-                rxSystemTotalInMb = rxTotalInBytes.bytesToMb(),
-                txSystemTotalInMb = txTotalInBytes.bytesToMb(),
-                rxAppInMb = rxUidInBytes.bytesToMb(),
-                txAppInMb = txUidInBytes.bytesToMb()
-            )
+    ): NetworkInfo = when {
+        dto == NetworkInfoDto.INVALID -> {
+            NetworkInfo.INVALID
+        }
+        dto == NetworkInfoDto.NOT_SUPPORTED -> {
+            NetworkInfo.NOT_SUPPORTED
+        }
+        else -> {
+            with(dto) {
+                NetworkInfo(
+                    rxSystemTotalInMb = rxTotalInBytes.bytesToMb(),
+                    txSystemTotalInMb = txTotalInBytes.bytesToMb(),
+                    rxAppInMb = rxUidInBytes.bytesToMb(),
+                    txAppInMb = txUidInBytes.bytesToMb()
+                )
+            }
         }
     }
 }

--- a/kamper/modules/network/src/commonTest/kotlin/com/smellouk/kamper/network/repository/NetworkInfoMapperTest.kt
+++ b/kamper/modules/network/src/commonTest/kotlin/com/smellouk/kamper/network/repository/NetworkInfoMapperTest.kt
@@ -16,6 +16,13 @@ class NetworkInfoMapperTest {
     }
 
     @Test
+    fun `map dto should return not supported when dto not supported`() {
+        val networkInfo = classToTest.map(NetworkInfoDto.NOT_SUPPORTED)
+
+        assertEquals(NetworkInfo.NOT_SUPPORTED, networkInfo)
+    }
+
+    @Test
     fun `map dto should return valid network info`() {
         val networkInfo = classToTest.map(
             NetworkInfoDto(


### PR DESCRIPTION
resolves #26

<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
Added a logic that catches when devices are not supported and send a NOT_SUPPORTED object to let the client know about the issue. 

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#26

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Run the fix on android device >= 23 and on android device < 23. 

## ✅ Checklist
<!--- Just put an `x` in all the boxes that apply. -->

- [x] My code follows
  our [contribution guide](https://github.com/smellouk/kamper/blob/develop/CONTRIBUTING.md).
- [x] I have added unit tests to cover the changes.
- [x] I have used and tested this on my device(s).
- [x] I have cleaned commit history.
- [ ] I have updated [README.md](https://github.com/smellouk/kamper/blob/develop/README.md) (if
  applicable)